### PR TITLE
Fix Next.js lint issues

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Image from "next/image";
 import WebcamCapture from "@/components/WebcamCapture";
 
 export default function CapturePage() {
@@ -8,7 +9,6 @@ export default function CapturePage() {
   const [mode, setMode] = useState<"login" | "logout">("login");
   const [status, setStatus] = useState("");
   const [imageData, setImageData] = useState<string | null>(null);
-  const [location, setLocation] = useState<{ lat: number; lng: number } | null>(null);
 
   const getLocation = () => {
     return new Promise<{ lat: number; lng: number }>((resolve, reject) => {
@@ -22,7 +22,7 @@ export default function CapturePage() {
                 lng: position.coords.longitude,
               });
             },
-            (err) => reject("Location access denied")
+            () => reject("Location access denied")
         );
       }
     });
@@ -38,7 +38,6 @@ export default function CapturePage() {
 
     try {
       const coords = await getLocation();
-      setLocation(coords);
 
       const res = await fetch(`${process.env.NEXT_PUBLIC_SUPABASE_URL}/functions/v1/submit-log`, {
         method: "POST",
@@ -60,8 +59,9 @@ export default function CapturePage() {
         setSrn("");
         setImageData(null);
       }
-    } catch (err: any) {
-      setStatus("Error: " + err);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      setStatus("Error: " + message);
     }
   };
 
@@ -87,7 +87,7 @@ export default function CapturePage() {
 
         {!imageData && <WebcamCapture onCapture={setImageData} />}
         {imageData && (
-            <img src={imageData} alt="Captured" className="w-40 h-40 rounded shadow mb-4" />
+            <Image src={imageData} alt="Captured" width={160} height={160} className="w-40 h-40 rounded shadow mb-4" />
         )}
 
         <button

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import Image from "next/image";
 import WebcamCapture from "@/components/WebcamCapture";
 import { useRouter } from "next/navigation";
 import { supabase } from "@/lib/supabaseClient";
 
 export default function RegisterPage() {
-    // @ts-ignore
-    const [user, setUser] = useState<never>(null);
     const [imageData, setImageData] = useState<string | null>(null);
     const [form, setForm] = useState({ srn: "", name: "", email: "", lab: "" });
     const [status, setStatus] = useState("");
@@ -17,10 +16,8 @@ export default function RegisterPage() {
     useEffect(() => {
         supabase.auth.getUser().then(({ data }) => {
             if (!data?.user) router.push("/login");
-            // @ts-expect-error
-            setUser(data.user);
         });
-    }, []);
+    }, [router]);
 
     const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const file = e.target.files?.[0];
@@ -100,7 +97,7 @@ export default function RegisterPage() {
                 </>
             )}
             {imageData && (
-                <img src={imageData} alt="Preview" className="w-40 h-40 rounded shadow mb-4" />
+                <Image src={imageData} alt="Preview" width={160} height={160} className="w-40 h-40 rounded shadow mb-4" />
             )}
 
             <button


### PR DESCRIPTION
## Summary
- clean up unused location state and handle errors
- use next/image for base64 snapshots
- remove unused `user` state in Register page
- add router dependency to `useEffect`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684a56787b408331b9f2c0f233b2a2a7