### PR TITLE
Add dashboard with stats and navigation

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import SideNav from '@/components/SideNav'
+import { supabase } from '@/lib/supabaseClient'
+import {
+  Chart,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Tooltip,
+  Legend,
+} from 'chart.js'
+import { Line } from 'react-chartjs-2'
+
+Chart.register(CategoryScale, LinearScale, PointElement, LineElement, Tooltip, Legend)
+
+interface Log {
+  id: string
+  srn: string
+  mode: string
+  created_at: string
+}
+
+export default function DashboardPage() {
+  const [logs, setLogs] = useState<Log[]>([])
+  const router = useRouter()
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => {
+      if (!data?.user) router.push('/login')
+    })
+
+    const fetchLogs = async () => {
+      const { data, error } = await supabase
+        .from('attendance_logs')
+        .select('id, srn, mode, created_at')
+        .order('created_at', { ascending: false })
+        .limit(100)
+
+      if (!error && data) {
+        setLogs(data)
+      }
+    }
+
+    fetchLogs()
+  }, [router])
+
+  const recentLogins = logs.filter((l) => l.mode === 'login').slice(0, 10)
+  const counts: Record<string, number> = {}
+  logs.forEach((l) => {
+    if (l.mode === 'login' && l.created_at) {
+      const date = l.created_at.split('T')[0]
+      counts[date] = (counts[date] ?? 0) + 1
+    }
+  })
+  const labels = Object.keys(counts).sort()
+  const chartData = {
+    labels,
+    datasets: [
+      {
+        label: 'Logins',
+        data: labels.map((d) => counts[d]),
+        borderColor: 'rgb(255, 159, 64)',
+        backgroundColor: 'rgba(255, 159, 64, 0.5)',
+      },
+    ],
+  }
+
+  return (
+    <div className="flex">
+      <SideNav />
+      <div className="flex-1 p-6">
+        <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
+        <div className="mb-6">
+          <h2 className="text-xl font-semibold mb-2">Last 10 Logins</h2>
+          <ul className="list-disc pl-5">
+            {recentLogins.map((log) => (
+              <li key={log.id}>
+                {log.srn} - {new Date(log.created_at).toLocaleString()}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h2 className="text-xl font-semibold mb-2">Daily Attendance</h2>
+          <Line data={chartData} />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/SideNav.tsx
+++ b/components/SideNav.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabaseClient'
+
+export default function SideNav() {
+  const router = useRouter()
+
+  const handleLogout = async () => {
+    await supabase.auth.signOut()
+    router.push('/login')
+  }
+
+  return (
+    <nav className="h-screen w-48 bg-gray-800 text-white p-4 flex flex-col gap-4">
+      <Link href="/dashboard" className="hover:text-orange-300">Dashboard</Link>
+      <Link href="/verify" className="hover:text-orange-300">Verify Records</Link>
+      <Link href="/register" className="hover:text-orange-300">Register Intern</Link>
+      <button onClick={handleLogout} className="mt-auto text-left hover:text-orange-300">
+        Logout
+      </button>
+    </nav>
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.1.0",
       "dependencies": {
         "@supabase/ssr": "^0.6.1",
+        "chart.js": "^4.4.9",
         "next": "15.3.3",
         "react": "^19.0.0",
+        "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.0.0",
         "react-webcam": "^7.2.0"
       },
@@ -767,6 +769,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.11",
@@ -2428,6 +2436,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.9.tgz",
+      "integrity": "sha512-EyZ9wWKgpAU0fLJ43YAEIF8sr5F2W3LqbS40ZJyHIner2lY14ufqv2VMp69MAiZ2rpwxEUxEhIH/0U3xyRynxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/chownr": {
@@ -5218,6 +5238,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
   },
   "dependencies": {
     "@supabase/ssr": "^0.6.1",
+    "chart.js": "^4.4.9",
     "next": "15.3.3",
     "react": "^19.0.0",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.0.0",
     "react-webcam": "^7.2.0"
   },


### PR DESCRIPTION
## Summary
- add SideNav component with links and logout
- create dashboard page showing recent logins and daily chart
- install chart.js and react-chartjs-2 for chart rendering

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684acef9b0088331a0bdb84ccf81024e