### PR TITLE
Add simple rPPG liveness check

### DIFF
--- a/components/WebcamCapture.tsx
+++ b/components/WebcamCapture.tsx
@@ -1,9 +1,18 @@
 "use client";
-import React, { useRef } from "react";
+import React, { useRef, useState, useEffect } from "react";
 import Webcam from "react-webcam";
+import { analyzeLiveness } from "@/lib/rppg";
 
 export default function WebcamCapture({ onCapture }: { onCapture: (img: string) => void }) {
     const webcamRef = useRef<Webcam>(null);
+    const [ready, setReady] = useState(false);
+    const [progress, setProgress] = useState(0);
+
+    useEffect(() => {
+        const video = webcamRef.current?.video as HTMLVideoElement | undefined;
+        if (!video) return;
+        analyzeLiveness(video, setProgress).then((ok) => setReady(ok));
+    }, []);
 
     const capture = () => {
         const imageSrc = webcamRef.current?.getScreenshot();
@@ -20,7 +29,19 @@ export default function WebcamCapture({ onCapture }: { onCapture: (img: string) 
                 className="rounded-lg shadow"
                 videoConstraints={{ facingMode: "user" }}
             />
-            <button onClick={capture} className="mt-2 px-4 py-2 bg-blue-600 text-white rounded">
+            {!ready && (
+                <div className="w-full bg-gray-200 rounded h-2 mt-2">
+                    <div
+                        className="bg-blue-600 h-2 rounded"
+                        style={{ width: `${Math.round(progress * 100)}%` }}
+                    />
+                </div>
+            )}
+            <button
+                onClick={capture}
+                disabled={!ready}
+                className="mt-2 px-4 py-2 bg-blue-600 text-white rounded disabled:opacity-50"
+            >
                 Capture Photo
             </button>
         </div>

--- a/lib/rppg.ts
+++ b/lib/rppg.ts
@@ -1,0 +1,34 @@
+import { fft, util as fftUtil } from 'fft-js';
+
+export async function analyzeLiveness(video: HTMLVideoElement, progressCb: (p: number) => void): Promise<boolean> {
+  const frameCount = 150; // about 5s at 30fps
+  const greens: number[] = [];
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+  canvas.width = video.videoWidth;
+  canvas.height = video.videoHeight;
+
+  for (let i = 0; i < frameCount; i++) {
+    ctx!.drawImage(video, 0, 0, canvas.width, canvas.height);
+    const data = ctx!.getImageData(0, 0, canvas.width, canvas.height).data;
+    let sum = 0;
+    for (let j = 0; j < data.length; j += 4) {
+      sum += data[j + 1]; // green channel
+    }
+    greens.push(sum / (data.length / 4));
+    progressCb((i + 1) / frameCount);
+    await new Promise(r => requestAnimationFrame(r));
+  }
+
+  const phasors = fft(greens);
+  const frequencies = fftUtil.fftFreq(phasors, 30); // approx fps
+  const mags = fftUtil.fftMag(phasors);
+  let best = { freq: 0, mag: 0 };
+  frequencies.forEach((f, idx) => {
+    const mag = mags[idx];
+    if (f > 0.8 && f < 3 && mag > best.mag) {
+      best = { freq: f, mag };
+    }
+  });
+  return best.mag > 20; // crude threshold
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@supabase/ssr": "^0.6.1",
         "chart.js": "^4.4.9",
+        "fft-js": "^0.0.12",
         "next": "15.3.3",
         "react": "^19.0.0",
         "react-chartjs-2": "^5.3.0",
@@ -2306,6 +2307,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bit-twiddle": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-1.0.2.tgz",
+      "integrity": "sha512-B9UhK0DKFZhoTFcfvAzhqsjStvGJp9vYWf3+6SNTtdSQnvIgfkHbgHrg/e4+TH71N2GDu8tpmCVoyfrL1d7ntA==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -2509,6 +2516,18 @@
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.7.1.tgz",
+      "integrity": "sha512-5qK/Wsc2fnRCiizV1JlHavWrSGAXQI7AusK423F8zJLwIGq8lmtO5GmO8PVMrtDUJMwTXOFBzSN6OCRD8CEMWw==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-readlink": ">= 1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6.x"
       }
     },
     "node_modules/concat-map": {
@@ -3407,6 +3426,19 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fft-js": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/fft-js/-/fft-js-0.0.12.tgz",
+      "integrity": "sha512-nLOa0/SYYnN2NPcLrI81UNSPxyg3q0sGiltfe9G1okg0nxs5CqAwtmaqPQdGcOryeGURaCoQx8Y4AUkhGTh7IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bit-twiddle": "~1.0.2",
+        "commander": "~2.7.1"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -3660,6 +3692,12 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==",
+      "license": "MIT"
     },
     "node_modules/graphemer": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@supabase/ssr": "^0.6.1",
     "chart.js": "^4.4.9",
+    "fft-js": "^0.0.12",
     "next": "15.3.3",
     "react": "^19.0.0",
     "react-chartjs-2": "^5.3.0",


### PR DESCRIPTION
## Summary
- integrate fft-js package
- add a simple rPPG-based liveness check
- disable capture button until analysis completes and show progress

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bc8140cb8833189f6e8b8b6f5ce70