### PR TITLE
Add lab dropdown for registration

### DIFF
--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -11,6 +11,7 @@ import nav from "@/public/nav-logo.png";
 export default function RegisterPage() {
     const [imageData, setImageData] = useState<string | null>(null);
     const [form, setForm] = useState({ srn: "", name: "", email: "", lab: "" });
+    const labs = ["CAVE Labs", "ISFCR", "MARS", "C-IoT"];
     const [status, setStatus] = useState("");
 
     const router = useRouter();
@@ -111,12 +112,20 @@ export default function RegisterPage() {
                             onChange={(e) => setForm({ ...form, email: e.target.value })}
                             className="w-full p-2 mb-2 rounded bg-white text-black"
                         />
-                        <input
-                            placeholder="Lab"
+                        <select
                             value={form.lab}
                             onChange={(e) => setForm({ ...form, lab: e.target.value })}
                             className="w-full p-2 mb-4 rounded bg-white text-black"
-                        />
+                        >
+                            <option value="" disabled>
+                                Select Lab
+                            </option>
+                            {labs.map((lab) => (
+                                <option key={lab} value={lab}>
+                                    {lab}
+                                </option>
+                            ))}
+                        </select>
 
                         {!imageData && (
                             <>


### PR DESCRIPTION
## Summary
- add available labs to registration page
- switch lab input to dropdown for lab selection

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_684e65862ba48331b744f6fdf158fde7