### PR TITLE
Add video capture on attendance page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
-import WebcamCapture from '@/components/WebcamCapture'
+import WebcamPhotoVideoCapture from '@/components/WebcamPhotoVideoCapture'
 import vrDoctorsImg from '@/public/login-side.png'
 import caveLogo from '@/public/cave-logo1.png'
 
@@ -12,6 +12,7 @@ export default function CapturePage() {
   const [mode, setMode] = useState<'login' | 'logout'>('login')
   const [status, setStatus] = useState('')
   const [imageData, setImageData] = useState<string | null>(null)
+  const [videoData, setVideoData] = useState<string | null>(null)
 
   const getLocation = () => {
     return new Promise<{ lat: number; lng: number }>((resolve, reject) => {
@@ -34,8 +35,8 @@ export default function CapturePage() {
   const handleSubmit = async () => {
     setStatus('Submitting...')
 
-    if (!srn || !imageData) {
-      setStatus('Please enter SRN and capture a photo')
+    if (!srn || !imageData || !videoData) {
+      setStatus('Please enter SRN and capture a photo and video')
       return
     }
 
@@ -51,6 +52,7 @@ export default function CapturePage() {
           latitude: coords.lat,
           longitude: coords.lng,
           imageBase64: imageData,
+          videoBase64: videoData,
         }),
       })
 
@@ -61,6 +63,7 @@ export default function CapturePage() {
         setStatus('Attendance submitted successfully.')
         setSrn('')
         setImageData(null)
+        setVideoData(null)
       }
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err)
@@ -97,7 +100,14 @@ export default function CapturePage() {
               <option value="logout">Logout</option>
             </select>
 
-            {!imageData && <WebcamCapture onCapture={setImageData} />}
+            {!imageData && !videoData && (
+                <WebcamPhotoVideoCapture
+                    onCapture={(img, vid) => {
+                        setImageData(img)
+                        setVideoData(vid)
+                    }}
+                />
+            )}
             {imageData && (
                 <Image
                     src={imageData}

--- a/components/WebcamPhotoVideoCapture.tsx
+++ b/components/WebcamPhotoVideoCapture.tsx
@@ -56,7 +56,10 @@ export default function WebcamPhotoVideoCapture({ onCapture }: { onCapture: (img
         if (!imageSrc || !stream) return;
 
         chunksRef.current = [];
-        mediaRecorderRef.current = new MediaRecorder(stream, { mimeType: "video/webm" });
+        mediaRecorderRef.current = new MediaRecorder(stream, {
+            mimeType: "video/webm;codecs=vp9",
+            videoBitsPerSecond: 2500000,
+        });
         mediaRecorderRef.current.ondataavailable = (e) => {
             if (e.data.size > 0) chunksRef.current.push(e.data);
         };
@@ -92,8 +95,9 @@ export default function WebcamPhotoVideoCapture({ onCapture }: { onCapture: (img
                 ref={webcamRef}
                 audio
                 screenshotFormat="image/jpeg"
+                screenshotQuality={1}
                 className="rounded-lg shadow"
-                videoConstraints={{ facingMode: "user" }}
+                videoConstraints={{ facingMode: "user", width: 1280, height: 720 }}
             />
             {capturing && (
                 <div className="w-full bg-gray-200 rounded h-2 mt-2">

--- a/components/WebcamPhotoVideoCapture.tsx
+++ b/components/WebcamPhotoVideoCapture.tsx
@@ -1,0 +1,119 @@
+"use client";
+import React, { useRef, useState, useEffect } from "react";
+import Webcam from "react-webcam";
+
+export default function WebcamPhotoVideoCapture({ onCapture }: { onCapture: (img: string, video: string) => void }) {
+    const webcamRef = useRef<Webcam>(null);
+    const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+    const chunksRef = useRef<Blob[]>([]);
+    const [spoofDetected, setSpoofDetected] = useState(false);
+    const [capturing, setCapturing] = useState(false);
+    const [progress, setProgress] = useState(0);
+
+    useEffect(() => {
+        const canvas = document.createElement("canvas");
+        canvas.width = 32;
+        canvas.height = 32;
+        const ctx = canvas.getContext("2d");
+        let prevData: Uint8ClampedArray | null = null;
+        let staticCount = 0;
+
+        const checkInterval = setInterval(() => {
+            const video = webcamRef.current?.video;
+            if (!video || video.readyState !== 4 || !ctx) return;
+
+            ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+            const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+
+            if (prevData) {
+                let diff = 0;
+                for (let i = 0; i < data.length; i += 4) {
+                    diff += Math.abs(data[i] - prevData[i]);
+                    diff += Math.abs(data[i + 1] - prevData[i + 1]);
+                    diff += Math.abs(data[i + 2] - prevData[i + 2]);
+                }
+                const avgDiff = diff / (data.length / 4);
+                if (avgDiff < 5) {
+                    staticCount += 1;
+                } else {
+                    staticCount = 0;
+                }
+                if (staticCount >= 3) {
+                    setSpoofDetected(true);
+                } else {
+                    setSpoofDetected(false);
+                }
+            }
+            prevData = new Uint8ClampedArray(data);
+        }, 700);
+
+        return () => clearInterval(checkInterval);
+    }, []);
+
+    const startCapture = () => {
+        const imageSrc = webcamRef.current?.getScreenshot();
+        const stream = webcamRef.current?.stream;
+        if (!imageSrc || !stream) return;
+
+        chunksRef.current = [];
+        mediaRecorderRef.current = new MediaRecorder(stream, { mimeType: "video/webm" });
+        mediaRecorderRef.current.ondataavailable = (e) => {
+            if (e.data.size > 0) chunksRef.current.push(e.data);
+        };
+        mediaRecorderRef.current.onstop = () => {
+            const blob = new Blob(chunksRef.current, { type: "video/webm" });
+            const reader = new FileReader();
+            reader.onloadend = () => {
+                const videoBase64 = reader.result as string;
+                onCapture(imageSrc, videoBase64);
+                setCapturing(false);
+                setProgress(0);
+            };
+            reader.readAsDataURL(blob);
+        };
+
+        mediaRecorderRef.current.start();
+        setCapturing(true);
+        setProgress(0);
+        let elapsed = 0;
+        const interval = setInterval(() => {
+            elapsed += 1;
+            setProgress((elapsed / 10) * 100);
+            if (elapsed >= 10) {
+                clearInterval(interval);
+                mediaRecorderRef.current?.stop();
+            }
+        }, 1000);
+    };
+
+    return (
+        <div className="flex flex-col items-center">
+            <Webcam
+                ref={webcamRef}
+                audio
+                screenshotFormat="image/jpeg"
+                className="rounded-lg shadow"
+                videoConstraints={{ facingMode: "user" }}
+            />
+            {capturing && (
+                <div className="w-full bg-gray-200 rounded h-2 mt-2">
+                    <div className="bg-blue-600 h-2 rounded" style={{ width: `${progress}%` }} />
+                </div>
+            )}
+            <button
+                onClick={startCapture}
+                disabled={spoofDetected || capturing}
+                className={`mt-2 px-4 py-2 bg-blue-600 text-white rounded ${
+                    spoofDetected || capturing ? "opacity-50 cursor-not-allowed" : ""
+                }`}
+            >
+                Capture
+            </button>
+            {spoofDetected && (
+                <p className="text-red-600 text-sm mt-1 text-center">
+                    No movement detected. Please ensure you are not using a static photo.
+                </p>
+            )}
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary
- add `WebcamPhotoVideoCapture` component that records a 10 second video with a progress bar and liveness detection
- update the main attendance page to capture video and photo together and send both to the backend

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684e6ab16e508331810201569a7f5d8f